### PR TITLE
onscan.js - Proposed Changes

### DIFF
--- a/onscan.js
+++ b/onscan.js
@@ -16,7 +16,7 @@ export let onScan = {
 			onPaste: function(sPasted, oEvent){}, // Callback after receiving a value on paste, no matter if it is a valid code or not
 			keyCodeMapper: function(oEvent){return String.fromCharCode(oEvent.which)}, // Custom function to decode a keydown event into a character. Must return decoded character or NULL if the given event should not be processed.
 			onScanButtonLongPress: function(){}, // Callback after detection of a successfull scan while the scan button was pressed and held down
-			scanButtonKeyCode:false, // Key code of the scanner hardware button (if the scanner button a acts as a key itself)
+			scanButtonKeyCode:false, // Key code of the scanner hardware button (if the scanner button a acts as a key itself) 
 			scanButtonLongPressTime:500, // How long (ms) the hardware button should be pressed, until a callback gets executed
 			timeBeforeScanTest:100, // Wait duration (ms) after keypress event to check if scanning is finished
 			avgTimeByChar:30, // Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
@@ -30,7 +30,7 @@ export let onScan = {
 			reactToPaste:false, // look for scan input in paste events
 			singleScanQty: 1 // Quantity of Items put out to onScan in a single scan
 		}
-
+								
 		oOptions = this._mergeOptions(oDefaults, oOptions);
 
 		// initializing options and variables on DomElement
@@ -45,9 +45,9 @@ export let onScan = {
 					longPressTimeStart: 0,
 					longPressed: false
 				}
-
+			
 		};
-
+		
 		// initializing handlers (based on settings)
 		if (oOptions.reactToPaste === true){
 			oDomElement.addEventListener("paste", this._handlePaste);
@@ -55,11 +55,11 @@ export let onScan = {
 		if (oOptions.scanButtonKeyCode !== false){
 			oDomElement.addEventListener("keyup", this._handleKeyUp);
 		}
-		if (oOptions.reactToKeydown === true || oOptions.scanButtonKeyCode !== false){
+		if (oOptions.reactToKeydown === true || oOptions.scanButtonKeyCode !== false){	
 			oDomElement.addEventListener("keydown", this._handleKeyDown);
 		}
 	},
-
+	
 	detachFrom: function(oDomElement) {
 		// detaching all used events
 		if (oDomElement.scannerDetectionData.options.reactToPaste){
@@ -69,20 +69,20 @@ export let onScan = {
 			oDomElement.removeEventListener("keyup", this._handleKeyUp);
 		}
 		oDomElement.removeEventListener("keydown", this._handleKeyDown);
-
+		
 		// clearing data off DomElement
-		oDomElement.scannerDetectionData = undefined;
-
+		oDomElement.scannerDetectionData = undefined; 
+		
 	},
-
+	
 	getOptions: function(oDomElement){
-		return oDomElement.scannerDetectionData.options;
+		return oDomElement.scannerDetectionData.options;			
 	},
-
+	
 	setOptions: function(oDomElement, oOptions){
 		// check if some handlers need to be changed based on possible option changes
 		switch (oDomElement.scannerDetectionData.options.reactToPaste){
-			case true:
+			case true: 
 				if (oOptions.reactToPaste === false){
 					oDomElement.removeEventListener("paste", this._handlePaste);
 				}
@@ -93,28 +93,28 @@ export let onScan = {
 				}
 				break;
 		}
-
+		
 		switch (oDomElement.scannerDetectionData.options.scanButtonKeyCode){
 			case false:
 				if (oOptions.scanButtonKeyCode !== false){
 					oDomElement.addEventListener("keyup", this._handleKeyUp);
 				}
 				break;
-			default:
+			default: 
 				if (oOptions.scanButtonKeyCode === false){
 					oDomElement.removeEventListener("keyup", this._handleKeyUp);
 				}
 				break;
 		}
-
+		
 		// merge old and new options
 		oDomElement.scannerDetectionData.options = this._mergeOptions(oDomElement.scannerDetectionData.options, oOptions);
-
+	
 		// reinitiallize
 		this._reinitialize(oDomElement);
 	},
-
-
+	
+		
 	simulate: function(oDomElement, sTestString){
 		var oVars = oDomElement['scannerDetectionData'].vars;
 		oVars.firstCharTime = 0;
@@ -123,14 +123,14 @@ export let onScan = {
 		this._validateScanCode(oDomElement);
 		return this;
 	},
-
+	
 	_reinitialize: function(oDomElement){
 		var oVars = oDomElement['scannerDetectionData'].vars;
 		oVars.firstCharTime = 0;
 		oVars.stringWriting = '';
 
 	},
-
+	
 	_isFocusOnIgnoredElement: function(oDomElement){
 
 	var ignoreSelectors = oDomElement['scannerDetectionData'].options.ignoreIfFocusOn;
@@ -138,9 +138,9 @@ export let onScan = {
         if(!ignoreSelectors){
 			return false;
 		}
-
+	
 		var oFocused = document.activeElement;
-
+		
 		// checks if ignored element is an array, and if so it checks if one of the elements of it is an active one
 		if (Array.isArray(ignoreSelectors)){
 			for(var i=0; i<ignoreSelectors.length; i++){
@@ -150,15 +150,15 @@ export let onScan = {
 			}
 		// if the option consists of an single element, it only checks this one
 		} else if (oFocused.matches(ignoreSelectors)){
-			return true;
+			return true;					
 		}
-
+		
 		// if the active element is not listed in the ignoreIfFocusOn option, return false
 	    return false;
     },
-
+	
 	_validateScanCode: function(oDomElement){
-		var oScannerData = oDomElement['scannerDetectionData'];
+		var oScannerData = oDomElement['scannerDetectionData'];			
 		var oOptions = oScannerData.options;
 		var iSingleScanQty = oScannerData.options.singleScanQty
 		var sScanCode = oScannerData.vars.stringWriting;
@@ -168,28 +168,28 @@ export let onScan = {
         var oEvent;
 
 		switch(true){
-
+			
 			// detect codes that are too short
 			case (sScanCode.length<oOptions.minLength):
 				oScanError = {
 					message: "Receieved code is shorter then minimal length"
 				};
 				break;
-
-			// detect codes that were entered too slow
+				
+			// detect codes that were entered too slow	
 			case ((iLastCharTime - iFirstCharTime) > (sScanCode.length * oOptions.avgTimeByChar)):
 				oScanError = {
 					message: "Receieved code was not entered in time"
-				};
+				};				
 				break;
-
-			// if a code was not filtered out earlier it is valid
+				
+			// if a code was not filtered out earlier it is valid	
 			default:
 				oOptions.onScan.call(oDomElement, sScanCode, iSingleScanQty);
 				oEvent = new CustomEvent(
 					'scan',
-					{
-						detail: {
+					{	
+						detail: { 
 							scanCode: sScanCode,
 							qty: iSingleScanQty
 						}
@@ -199,24 +199,24 @@ export let onScan = {
 				onScan._reinitialize(oDomElement);
 				return true;
 		}
-
+		
 		// If an error occurred (otherwise the method would return earlier) create an object for errordetection
 		oScanError.scanCode = sScanCode;
 		oScanError.scanDuration = iLastCharTime - iFirstCharTime;
 		oScanError.avgTimeByChar = oOptions.avgTimeByChar;
 		oScanError.minLength = oOptions.minLength;
-
+		
 		oOptions.onScanError.call(oDomElement, oScanError);
-
+		
 		var oEvent = new CustomEvent(
 			'scanError',
 			oScanError
 		);
 		oDomElement.dispatchEvent(oEvent);
-
+		
 		onScan._reinitialize(oDomElement);
 		return false;
-
+		
     },
 
 	_mergeOptions: function(oDefaults, oOptions){
@@ -226,20 +226,20 @@ export let onScan = {
 			if (Object.prototype.hasOwnProperty.call(oDefaults, prop)){
 				oExtended[prop] = oDefaults[prop];
 			}
-		}
+		}			
 		for (prop in oOptions){
 			if (Object.prototype.hasOwnProperty.call(oOptions, prop)){
 				oExtended[prop] = oOptions[prop];
 			}
-		}
+		}			
 		return oExtended;
 	},
 
 	_getNormalizedKeyNum: function(e){
-		var iKeyCode;
-		if(window.event) { // IE
+		var iKeyCode;  
+		if(window.event) { // IE                    
 		  iKeyCode = e.keyCode;
-		} else if(e.which){ // Netscape/Firefox/Opera
+		} else if(e.which){ // Netscape/Firefox/Opera                   
 		  iKeyCode = e.which;
 		}
 		return iKeyCode;
@@ -259,7 +259,7 @@ export let onScan = {
 
         // If it's just the button of the scanner, ignore it and wait for the real input
 	    if(oOptions.scanButtonKeyCode !== false && iKeyCode==oOptions.scanButtonKeyCode) {
-
+			
 			// if the button was first pressed, start a timeout for the callback, which gets interrupted if the scanbutton gets released
 			if (!oVars.longPressed){
 				oVars.longPressTimer = setTimeout( oOptions.onScanButtonLongPress, oOptions.scanButtonLongPressTime, this);
@@ -268,15 +268,15 @@ export let onScan = {
 
 			return;
         }
-
+		
 		if(oOptions.stopPropagation){
 			e.stopImmediatePropagation();
 		}
-
+		
 		if(oOptions.preventDefault){
 			e.preventDefault();
 		}
-
+		
 		switch(true){
 			// If it's not the first character and we encounter a terminating character, trigger scan process
 			case (oVars.firstCharTime && oOptions.suffixKeyCodes.indexOf(iKeyCode)!==-1):
@@ -284,15 +284,15 @@ export let onScan = {
 				e.stopImmediatePropagation();
 				this['scannerDetectionData'].vars.callIsScanner=true;
 				break;
-
-			// If it's the first character and we encountered one of the starting characters, don't process the scan
+				
+			// If it's the first character and we encountered one of the starting characters, don't process the scan	
 			case (!oVars.firstCharTime && oOptions.prefixKeyCodes.indexOf(iKeyCode)!==-1):
 				e.preventDefault();
 				e.stopImmediatePropagation();
 				oVars.callIsScanner=false;
 				break;
-
-			// Otherwise, just add the character to the scan string we're building
+				
+			// Otherwise, just add the character to the scan string we're building	
 			default:
 				var character = oOptions.keyCodeMapper.call(this, e);
 				if (character === null){
@@ -302,17 +302,17 @@ export let onScan = {
 				oVars.callIsScanner=false;
 				break;
 		}
-
+        
 		if(!oVars.firstCharTime){
 			oVars.firstCharTime=Date.now();
 		}
-
+		
 		oVars.lastCharTime=Date.now();
 
-		if(oVars.testTimer){
+		if(oVars.testTimer){ 
 			clearTimeout(oVars.testTimer);
 		}
-
+		
 		if(oVars.callIsScanner){
 			onScan._validateScanCode(this);
 			oVars.testTimer=false;
@@ -321,9 +321,9 @@ export let onScan = {
 		}
 
 		oOptions.onKeyProcess.call(this, character, e);
-
+		
 	},
-
+	
 	_handlePaste: function(e){
 
 		// if the focus is on an ignored element, abort
@@ -331,37 +331,37 @@ export let onScan = {
 			return;
 		}
 		e.preventDefault();
-
+					
 		var sPasteString = (event.clipboardData || window.clipboardData).getData('text');
 		this.scannerDetectionData.options.onPaste.call(this, sPasteString, event);
-
+		
 		var oVars = this.scannerDetectionData.vars;
 		oVars.firstCharTime = 0;
 		oVars.lastCharTime = 0;
 		oVars.stringWriting = sPasteString;
-
+		
 		// validate the string
 		onScan._validateScanCode(this);
 
 	},
-
+	
 	_handleKeyUp: function(e){
 		// if the focus is on an ignored element, abort
 		if (onScan._isFocusOnIgnoredElement(this)){
 			return;
 		}
-
+		
 		var iKeyCode = onScan._getNormalizedKeyNum(e);
-
+		
 		// if hardware key is not being pressed anymore stop the timeout and reset
 		if (iKeyCode == this.scannerDetectionData.options.scanButtonKeyCode){
 			clearTimeout(this.scannerDetectionData.vars.longPressTimer);
 			this.scannerDetectionData.vars.longPressed = false;
 		}
-
-
-
+		
+		
+		
 	}
-
-
+		
+		
 };

--- a/onscan.js
+++ b/onscan.js
@@ -1,10 +1,10 @@
 /*
  * onScan.js - scan-events for hardware barcodes scanners in javascript
  */
-var onScan = {		
+export let onScan = {
 	attachTo: function(oDomElement, oOptions) {
 
-		if(oDomElement.scannerDetectionData != undefined){
+		if(oDomElement.scannerDetectionData !== undefined){
 			throw new Error("onScan.js is already initialized for DOM element " + oDomElement);
 		}
 
@@ -16,7 +16,7 @@ var onScan = {
 			onPaste: function(sPasted, oEvent){}, // Callback after receiving a value on paste, no matter if it is a valid code or not
 			keyCodeMapper: function(oEvent){return String.fromCharCode(oEvent.which)}, // Custom function to decode a keydown event into a character. Must return decoded character or NULL if the given event should not be processed.
 			onScanButtonLongPress: function(){}, // Callback after detection of a successfull scan while the scan button was pressed and held down
-			scanButtonKeyCode:false, // Key code of the scanner hardware button (if the scanner button a acts as a key itself) 
+			scanButtonKeyCode:false, // Key code of the scanner hardware button (if the scanner button a acts as a key itself)
 			scanButtonLongPressTime:500, // How long (ms) the hardware button should be pressed, until a callback gets executed
 			timeBeforeScanTest:100, // Wait duration (ms) after keypress event to check if scanning is finished
 			avgTimeByChar:30, // Average time (ms) between 2 chars. Used to do difference between keyboard typing and scanning
@@ -30,7 +30,7 @@ var onScan = {
 			reactToPaste:false, // look for scan input in paste events
 			singleScanQty: 1 // Quantity of Items put out to onScan in a single scan
 		}
-								
+
 		oOptions = this._mergeOptions(oDefaults, oOptions);
 
 		// initializing options and variables on DomElement
@@ -45,9 +45,9 @@ var onScan = {
 					longPressTimeStart: 0,
 					longPressed: false
 				}
-			
+
 		};
-		
+
 		// initializing handlers (based on settings)
 		if (oOptions.reactToPaste === true){
 			oDomElement.addEventListener("paste", this._handlePaste);
@@ -55,11 +55,11 @@ var onScan = {
 		if (oOptions.scanButtonKeyCode !== false){
 			oDomElement.addEventListener("keyup", this._handleKeyUp);
 		}
-		if (oOptions.reactToKeydown === true || oOptions.scanButtonKeyCode !== false){	
+		if (oOptions.reactToKeydown === true || oOptions.scanButtonKeyCode !== false){
 			oDomElement.addEventListener("keydown", this._handleKeyDown);
 		}
 	},
-	
+
 	detachFrom: function(oDomElement) {
 		// detaching all used events
 		if (oDomElement.scannerDetectionData.options.reactToPaste){
@@ -69,20 +69,20 @@ var onScan = {
 			oDomElement.removeEventListener("keyup", this._handleKeyUp);
 		}
 		oDomElement.removeEventListener("keydown", this._handleKeyDown);
-		
+
 		// clearing data off DomElement
-		oDomElement.scannerDetectionData = undefined; 
-		
+		oDomElement.scannerDetectionData = undefined;
+
 	},
-	
+
 	getOptions: function(oDomElement){
-		return oDomElement.scannerDetectionData.options;			
+		return oDomElement.scannerDetectionData.options;
 	},
-	
+
 	setOptions: function(oDomElement, oOptions){
 		// check if some handlers need to be changed based on possible option changes
 		switch (oDomElement.scannerDetectionData.options.reactToPaste){
-			case true: 
+			case true:
 				if (oOptions.reactToPaste === false){
 					oDomElement.removeEventListener("paste", this._handlePaste);
 				}
@@ -93,28 +93,28 @@ var onScan = {
 				}
 				break;
 		}
-		
+
 		switch (oDomElement.scannerDetectionData.options.scanButtonKeyCode){
 			case false:
 				if (oOptions.scanButtonKeyCode !== false){
 					oDomElement.addEventListener("keyup", this._handleKeyUp);
 				}
 				break;
-			default: 
+			default:
 				if (oOptions.scanButtonKeyCode === false){
 					oDomElement.removeEventListener("keyup", this._handleKeyUp);
 				}
 				break;
 		}
-		
+
 		// merge old and new options
 		oDomElement.scannerDetectionData.options = this._mergeOptions(oDomElement.scannerDetectionData.options, oOptions);
-	
+
 		// reinitiallize
 		this._reinitialize(oDomElement);
 	},
-	
-		
+
+
 	simulate: function(oDomElement, sTestString){
 		var oVars = oDomElement['scannerDetectionData'].vars;
 		oVars.firstCharTime = 0;
@@ -123,24 +123,24 @@ var onScan = {
 		this._validateScanCode(oDomElement);
 		return this;
 	},
-	
+
 	_reinitialize: function(oDomElement){
 		var oVars = oDomElement['scannerDetectionData'].vars;
 		oVars.firstCharTime = 0;
 		oVars.stringWriting = '';
 
 	},
-	
+
 	_isFocusOnIgnoredElement: function(oDomElement){
-		
-		ignoreSelectors = oDomElement['scannerDetectionData'].options.ignoreIfFocusOn;
+
+	var ignoreSelectors = oDomElement['scannerDetectionData'].options.ignoreIfFocusOn;
 
         if(!ignoreSelectors){
 			return false;
 		}
-	
+
 		var oFocused = document.activeElement;
-		
+
 		// checks if ignored element is an array, and if so it checks if one of the elements of it is an active one
 		if (Array.isArray(ignoreSelectors)){
 			for(var i=0; i<ignoreSelectors.length; i++){
@@ -150,44 +150,46 @@ var onScan = {
 			}
 		// if the option consists of an single element, it only checks this one
 		} else if (oFocused.matches(ignoreSelectors)){
-			return true;					
+			return true;
 		}
-		
+
 		// if the active element is not listed in the ignoreIfFocusOn option, return false
 	    return false;
     },
-	
+
 	_validateScanCode: function(oDomElement){
-		var oScannerData = oDomElement['scannerDetectionData'];			
+		var oScannerData = oDomElement['scannerDetectionData'];
 		var oOptions = oScannerData.options;
 		var iSingleScanQty = oScannerData.options.singleScanQty
 		var sScanCode = oScannerData.vars.stringWriting;
 		var iFirstCharTime = oScannerData.vars.firstCharTime;
 		var iLastCharTime = oScannerData.vars.lastCharTime;
-	
+		var oScanError = {};
+        var oEvent;
+
 		switch(true){
-			
+
 			// detect codes that are too short
 			case (sScanCode.length<oOptions.minLength):
-				var oScanError = {
+				oScanError = {
 					message: "Receieved code is shorter then minimal length"
 				};
 				break;
-				
-			// detect codes that were entered too slow	
+
+			// detect codes that were entered too slow
 			case ((iLastCharTime - iFirstCharTime) > (sScanCode.length * oOptions.avgTimeByChar)):
-				var oScanError = {
+				oScanError = {
 					message: "Receieved code was not entered in time"
-				};				
+				};
 				break;
-				
-			// if a code was not filtered out earlier it is valid	
+
+			// if a code was not filtered out earlier it is valid
 			default:
 				oOptions.onScan.call(oDomElement, sScanCode, iSingleScanQty);
-				var oEvent = new CustomEvent(
+				oEvent = new CustomEvent(
 					'scan',
-					{	
-						detail: { 
+					{
+						detail: {
 							scanCode: sScanCode,
 							qty: iSingleScanQty
 						}
@@ -197,24 +199,24 @@ var onScan = {
 				onScan._reinitialize(oDomElement);
 				return true;
 		}
-		
+
 		// If an error occurred (otherwise the method would return earlier) create an object for errordetection
 		oScanError.scanCode = sScanCode;
 		oScanError.scanDuration = iLastCharTime - iFirstCharTime;
 		oScanError.avgTimeByChar = oOptions.avgTimeByChar;
 		oScanError.minLength = oOptions.minLength;
-		
+
 		oOptions.onScanError.call(oDomElement, oScanError);
-		
+
 		var oEvent = new CustomEvent(
 			'scanError',
 			oScanError
 		);
 		oDomElement.dispatchEvent(oEvent);
-		
+
 		onScan._reinitialize(oDomElement);
 		return false;
-		
+
     },
 
 	_mergeOptions: function(oDefaults, oOptions){
@@ -224,43 +226,40 @@ var onScan = {
 			if (Object.prototype.hasOwnProperty.call(oDefaults, prop)){
 				oExtended[prop] = oDefaults[prop];
 			}
-		}			
+		}
 		for (prop in oOptions){
 			if (Object.prototype.hasOwnProperty.call(oOptions, prop)){
 				oExtended[prop] = oOptions[prop];
 			}
-		}			
+		}
 		return oExtended;
 	},
 
 	_getNormalizedKeyNum: function(e){
-		var iKeyCode;  
-		if(window.event) { // IE                    
+		var iKeyCode;
+		if(window.event) { // IE
 		  iKeyCode = e.keyCode;
-		} else if(e.which){ // Netscape/Firefox/Opera                   
+		} else if(e.which){ // Netscape/Firefox/Opera
 		  iKeyCode = e.which;
 		}
 		return iKeyCode;
 	},
 
+	_handleKeyDown: function (e) {
+        // overwrite the which value of the event with keycode for cross platform compatibility
+        var iKeyCode = onScan._getNormalizedKeyNum(e);
+        var oOptions = this['scannerDetectionData'].options;
+        var oVars = this['scannerDetectionData'].vars;
 
+        oOptions.onKeyDetect.call(this, iKeyCode, e);
 
-	_handleKeyDown: function(e){
-		// overwrite the which value of the event with keycode for cross platform compatibility
-		e.which = onScan._getNormalizedKeyNum(e);
-		var iKeyCode = e.which;
-		var oOptions = this['scannerDetectionData'].options;
-		var oVars = this['scannerDetectionData'].vars;
-		
-		oOptions.onKeyDetect.call(this, e.which, e);		
-		
-		if (onScan._isFocusOnIgnoredElement(this)){
-			return;
-		}
-					
+        if (onScan._isFocusOnIgnoredElement(this)) {
+            return;
+        }
+
         // If it's just the button of the scanner, ignore it and wait for the real input
 	    if(oOptions.scanButtonKeyCode !== false && iKeyCode==oOptions.scanButtonKeyCode) {
-			
+
 			// if the button was first pressed, start a timeout for the callback, which gets interrupted if the scanbutton gets released
 			if (!oVars.longPressed){
 				oVars.longPressTimer = setTimeout( oOptions.onScanButtonLongPress, oOptions.scanButtonLongPressTime, this);
@@ -269,15 +268,15 @@ var onScan = {
 
 			return;
         }
-		
+
 		if(oOptions.stopPropagation){
 			e.stopImmediatePropagation();
 		}
-		
+
 		if(oOptions.preventDefault){
 			e.preventDefault();
 		}
-		
+
 		switch(true){
 			// If it's not the first character and we encounter a terminating character, trigger scan process
 			case (oVars.firstCharTime && oOptions.suffixKeyCodes.indexOf(iKeyCode)!==-1):
@@ -285,15 +284,15 @@ var onScan = {
 				e.stopImmediatePropagation();
 				this['scannerDetectionData'].vars.callIsScanner=true;
 				break;
-				
-			// If it's the first character and we encountered one of the starting characters, don't process the scan	
+
+			// If it's the first character and we encountered one of the starting characters, don't process the scan
 			case (!oVars.firstCharTime && oOptions.prefixKeyCodes.indexOf(iKeyCode)!==-1):
 				e.preventDefault();
 				e.stopImmediatePropagation();
 				oVars.callIsScanner=false;
 				break;
-				
-			// Otherwise, just add the character to the scan string we're building	
+
+			// Otherwise, just add the character to the scan string we're building
 			default:
 				var character = oOptions.keyCodeMapper.call(this, e);
 				if (character === null){
@@ -303,17 +302,17 @@ var onScan = {
 				oVars.callIsScanner=false;
 				break;
 		}
-        
+
 		if(!oVars.firstCharTime){
 			oVars.firstCharTime=Date.now();
 		}
-		
+
 		oVars.lastCharTime=Date.now();
 
-		if(oVars.testTimer){ 
+		if(oVars.testTimer){
 			clearTimeout(oVars.testTimer);
 		}
-		
+
 		if(oVars.callIsScanner){
 			onScan._validateScanCode(this);
 			oVars.testTimer=false;
@@ -322,9 +321,9 @@ var onScan = {
 		}
 
 		oOptions.onKeyProcess.call(this, character, e);
-		
+
 	},
-	
+
 	_handlePaste: function(e){
 
 		// if the focus is on an ignored element, abort
@@ -332,37 +331,37 @@ var onScan = {
 			return;
 		}
 		e.preventDefault();
-					
+
 		var sPasteString = (event.clipboardData || window.clipboardData).getData('text');
 		this.scannerDetectionData.options.onPaste.call(this, sPasteString, event);
-		
+
 		var oVars = this.scannerDetectionData.vars;
 		oVars.firstCharTime = 0;
 		oVars.lastCharTime = 0;
 		oVars.stringWriting = sPasteString;
-		
+
 		// validate the string
 		onScan._validateScanCode(this);
 
 	},
-	
+
 	_handleKeyUp: function(e){
 		// if the focus is on an ignored element, abort
 		if (onScan._isFocusOnIgnoredElement(this)){
 			return;
 		}
-		
+
 		var iKeyCode = onScan._getNormalizedKeyNum(e);
-		
+
 		// if hardware key is not being pressed anymore stop the timeout and reset
 		if (iKeyCode == this.scannerDetectionData.options.scanButtonKeyCode){
 			clearTimeout(this.scannerDetectionData.vars.longPressTimer);
 			this.scannerDetectionData.vars.longPressed = false;
 		}
-		
-		
-		
+
+
+
 	}
-		
-		
+
+
 };


### PR DESCRIPTION
Want to include onscan.js as part of our package.json and yarn install and need to have the onScan object exported so we can import it into our code.
                         export let onScan = {...

Additional Proposed Changes:

       attachTo():
       Use strict comparison: if(oDomElement.scannerDetectionData !== undefined){...

       _isFocusOnIgnoredElement:
       Add var to arg declaration: var ignoreSelectors = oDomElement['scannerDetectionData'].options.ignoreIfFocusOn;

       _validateScanCode: 
       Predefine arguments oScanError & oEvent

      _handleKeyDown:
      Eliminate setting e.which - this is causing js errors in our code because it is read-only